### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "dependencies": {
     "oauth": "git://github.com/SocialBro/node-oauth.git",
     "cookies": "0.1.x",
-    "keygrip": "0.1.x",
+    "keygrip": "1.0.1",
     "qs": "~0.5.6"
   },
   "engines": {


### PR DESCRIPTION
Update keygrip to version 1.0.1 to prevent usage of old 'path' API.
Newer versions of Node throw an error with this log: path.existsSync is now called `fs.existsSync`.
